### PR TITLE
Update documentation to reflect API change

### DIFF
--- a/documentation/composition.md
+++ b/documentation/composition.md
@@ -232,7 +232,7 @@ Those are the main scenarios. Hopefully you can see some of the differences from
                     <StackPanel Orientation="Horizontal">
                         <TextBlock Text="{Binding DisplayName}" />
                         <Button Content="X"
-                                cal:Message.Attach="CloseItem($dataContext)" />
+                                cal:Message.Attach="DeactivateItem($dataContext, 'true')" />
                     </StackPanel>
                 </DataTemplate>
             </TabControl.ItemTemplate>


### PR DESCRIPTION
CloseItem no longer exists in IConductor. Anyone following the example by copy pasting code will get an exception. 

See:
https://stackoverflow.com/questions/11867249/caliburn-micro-cannot-close-tab