### PR TITLE
Documentation minor changes

### DIFF
--- a/documentation/Tutorials/WPF/AddDialogToShellView.md
+++ b/documentation/Tutorials/WPF/AddDialogToShellView.md
@@ -2,6 +2,7 @@
 layout: page
 title: Add the About Dialog Form to the ShellViewModel
 ---
+
 [Contents](Contents) [Previous](DialogForm)
 
 ## Add the Dialog Form to the ShellViewModel

--- a/documentation/Tutorials/WPF/App_Xaml.md
+++ b/documentation/Tutorials/WPF/App_Xaml.md
@@ -58,7 +58,7 @@ The resulting code should look like this:
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:Caliburn.Micro.Tutorial.Wpf">
-    <Application.Resources
+    <Application.Resources>
       <ResourceDictionary>
            <ResourceDictionary.MergedDictionaries>
                <ResourceDictionary>

--- a/documentation/Tutorials/WPF/App_Xaml.md
+++ b/documentation/Tutorials/WPF/App_Xaml.md
@@ -2,6 +2,7 @@
 layout: page
 title: Change App.xaml
 ---
+
 [Contents](Contents) [Previous](Bootstrapper) [Next](SimpleLogging)
 
 ## Change App.Xaml

--- a/documentation/Tutorials/WPF/Categories1.md
+++ b/documentation/Tutorials/WPF/Categories1.md
@@ -134,7 +134,7 @@ namespace Caliburn.Micro.Tutorial.Wpf.ViewModels
 
 This is a fairly long code fragment. Now each part of it will be discussed separately. A large part of the ViewModel is devoted to represent the data you need in the View.
 
-The first thing you can see is that the ViewModel inherits from ``Screen``. As the name says, it will allow the use of a single user control or window. In a later chapter of this tutorial, this will be explained in more detail. You also can read [this article](/documentation/Composition.md) in the documentation.
+The first thing you can see is that the ViewModel inherits from ``Screen``. As the name says, it will allow the use of a single user control or window. In a later chapter of this tutorial, this will be explained in more detail. You also can read [this article](/documentation/composition.md) in the documentation.
 
 ``BindableCollection<CategoryModel> CategoryList``
 CategoryList is a List containing all categories. It is used in the ``DataGrid`` we will define in the View.

--- a/documentation/Tutorials/WPF/ConditionalExecution.md
+++ b/documentation/Tutorials/WPF/ConditionalExecution.md
@@ -9,7 +9,7 @@ title: Expenses Logbook introduction
 
 ### Introduction
 
-In WPF applications you can disable a button using ``IsEnabled="false"`` in the XAML code. You can bind this to a property in the code behind, or define the conditions in the code behind. In Caliburn.Micro the ViewModel can determine conditions that must be met in order to execute a command. For example, The ``Edit()`` command is tied to the Button named ``Edit`` in the view. It would e nice if we can disable it if the ``SelectedCategory`` is ``null``.
+In WPF applications you can disable a button using ``IsEnabled="false"`` in the XAML code. You can bind this to a property in the code behind, or define the conditions in the code behind. In Caliburn.Micro the ViewModel can determine conditions that must be met in order to execute a command. For example, The ``Edit()`` command is tied to the Button named ``Edit`` in the view. It would be nice if we can disable it if the ``SelectedCategory`` is ``null``.
 
 ### The Caliburn.Micro solution
 

--- a/documentation/Tutorials/WPF/Contents.md
+++ b/documentation/Tutorials/WPF/Contents.md
@@ -2,6 +2,7 @@
 layout: page
 title: Contents
 ---
+
 ## Contents
 
 [Documentation index](../../Index)

--- a/documentation/Tutorials/WPF/DialogForm.md
+++ b/documentation/Tutorials/WPF/DialogForm.md
@@ -1,9 +1,8 @@
-
-
 ---
 layout: page
 title: Create a Dialog Form
 ---
+
 [Contents](Contents) [Previous](SimpleContainer) [Next](AddDialogToShellView)
 
 ## Create a simple dialog form

--- a/documentation/Tutorials/WPF/Introduce_Caliburn.md
+++ b/documentation/Tutorials/WPF/Introduce_Caliburn.md
@@ -3,7 +3,7 @@ layout: page
 title: Introduce Caliburn
 ---
 
-[Contents](Contents) [Previous](SolutionSetup) [Next](Bootstrapper)
+[Contents](Contents) [Previous](SolutionSetup) [Next](ShellViewModel)
 
 ## Introduce Caliburn.Micro
 
@@ -23,4 +23,4 @@ Alternatively, you can rename MainWindow.xaml to ShellView.xaml and move it to t
 
 Essentially, you need to perform the same steps to migrate an existing WPF application to a Caliburn.Micro application. Of course, this does not make the application and MVVM application.
 
-[Contents](Contents) [Previous](SolutionSetup) [Next](Bootstrapper)
+[Contents](Contents) [Previous](SolutionSetup) [Next](ShellViewModel)

--- a/documentation/Tutorials/WPF/ShellView.md
+++ b/documentation/Tutorials/WPF/ShellView.md
@@ -13,7 +13,7 @@ Caliburn.Micro promotes a programming style where you use one window and then sh
 
 ### Create the ShellView class
 
-Since we already created a class ``ShelViewModel`` we also need a WPF Window named ``ShellView``, so create a new WPF Window class in the View folder. You do not need any specific inheritance here.
+Since we already created a class ``ShellViewModel`` we also need a WPF Window named ``ShellView``, so create a new WPF Window class in the View folder. You do not need any specific inheritance here.
 
 ### Add a content control
 

--- a/documentation/Tutorials/WPF/SimpleContainer.md
+++ b/documentation/Tutorials/WPF/SimpleContainer.md
@@ -9,7 +9,7 @@ title: Add a simple container
 
 In this part of the WPF Tutorial an Inversion of Control Container will be added. This container is a kind of dispenser for class objects. You also will find the term Dependency Injection used often. You can do without and use new statements to instantiate class objects, but for complex applications using a container is considered best practice for good reasons. For more background, one of your options is to watch this video: [Tim Corey Dependency Inversion tutorial](https://www.youtube.com/watch?v=NnZZMkwI6KI)
 
-For this tutorial a Caliburn.Micro ``SimpleContainer`` will be used. Make following changes t ``Bootstrapper.cs``:
+For this tutorial a Caliburn.Micro ``SimpleContainer`` will be used. Make following changes to ``Bootstrapper.cs``:
 
 Add an interface to the container:
 
@@ -54,7 +54,7 @@ If you need it can do something like this to get access to the container:
 var container = IoC.Get<SimpleContainer>();
 ```
 
-Next, two interfaces are added tot the container as ``Singleton`` which means only one instance will be created and the instance will be used repeatedly. You should consider carefully if you really need to use a single instance container.
+Next, two interfaces are added to the container as ``Singleton`` which means only one instance will be created and the instance will be used repeatedly. You should consider carefully if you really need to use a single instance container.
 
 ```C#
  _container

--- a/documentation/Tutorials/WPF/SimpleLogging.md
+++ b/documentation/Tutorials/WPF/SimpleLogging.md
@@ -2,6 +2,7 @@
 layout: page
 title: Simple logging
 ---
+
 [Contents](Contents) [Previous](App_Xaml) [Next](ExpensesLogbook)
 
 ## Simple logging


### PR DESCRIPTION
Minor corrections on the docs including.
- Typos
- Broken links
- Navigate to next section in the wpf tutorial
- Leaving empty line after layout, title section of the markdown document, for consistency with all other markdown documents