### PR TITLE
fix typo

### DIFF
--- a/documentation/nuget.md
+++ b/documentation/nuget.md
@@ -61,7 +61,7 @@ For WinRT, the process of getting started is unfortunately quite different from 
 
 
 ##### .net Maui
-For .net Maui, the process of getting started is unfortunately quite different from the other platforms because the app provides output for multiple platforms. For detailed instructions please see [Working with WinRT](./dotnet-maui.md).
+For .net Maui, the process of getting started is unfortunately quite different from the other platforms because the app provides output for multiple platforms. For detailed instructions please see [Working with .net Maui](./dotnet-maui.md).
 
 ##### Avalonia UI
 For detailed instructions on using Caliburn.Micro with Avalonia UI see [Working with AvaloniaUI](/AvaloniaUI.md)


### PR DESCRIPTION
This pull request includes a minor update to the `documentation/nuget.md` file. The change corrects a reference link for .NET Maui documentation.

Documentation update:

* [`documentation/nuget.md`](diffhunk://#diff-974e6e8b73f9332c2edd76ee94bdf566d4221627971ae80c4ca8fcc7cf7ac18dL64-R64): Updated the link text from "Working with WinRT" to "Working with .net Maui" to accurately reflect the content of the linked document.